### PR TITLE
If you are open to some ideas...

### DIFF
--- a/clone-hr.sh
+++ b/clone-hr.sh
@@ -9,7 +9,8 @@ FEC=false
 # FEC Helper function for getting team name is userPrompt runs
 promptTeam() {
   echo "What is your FEC organization name (as created/entered on GitHub)?"
-  read TEAM
+  read INPUT_TEAM
+  TEAM=$INPUT_TEAM
   FEC=true
 }
 
@@ -17,22 +18,23 @@ promptTeam() {
 promptUser() {
   # Prompt user for github handle
   echo "What is your GitHub username?"
-  read USER
+  read INPUT_USER
+  USER=$INPUT_USER
 
   # Prompt user for Cohort id
   echo "What is your COHORT ID? (i.e hrr47)"
-  read COHORT
+  read INPUT_COHORT
+  COHORT=$INPUT_COHORT
 
   # Prompt user on whether they have started/completed FEC
-  echo "Have you started or completed FEC? (y[es] / n[o])"
-  # Tells user to respond with y/n if invalid input
-  select yn in "Yes" "No"
-  case $yn in
-    # If yes, run promptTeam helper
-    Yes ) promptTeam;;
-    # If no, set FEC to false
-    No ) FEC=false;;
-  esac
+  while true; do
+    read -p "Have you started or completed FEC? (y[es] / n[o])" yn
+    case $yn in
+        [Yy]* ) promptTeam; break;;
+        [Nn]* ) FEC=false;;
+        * ) echo "Please answer yes or no.";;
+    esac
+  done
 }
 
 # If the three required options aren't included in prompt, run promptUser

--- a/clone-hr.sh
+++ b/clone-hr.sh
@@ -1,19 +1,51 @@
 #!/bin/bash
 
-if [ $# != 2 ]; then
-  echo "Please provide username and cohort id when calling"
-  echo "i.e. \"sh clone-hackreactor.sh lennee hrr47\""
-  exit 1;
-fi
+# REQUIRED SCRIPT VARIABLES
+USER="$1"
+COHORT="$2"
+TEAM="$3"
+FEC=false
 
-
-user="$1"
-cohort="$2"
-
-clone () {
-  git clone "https://github.com/$user/$1"
+# FEC Helper function for getting team name is userPrompt runs
+promptTeam() {
+  echo "What is your FEC organization name (as created/entered on GitHub)?"
+  read TEAM
+  FEC=true
 }
 
+# Creates a function to prompt user if no options are given when script is run
+promptUser() {
+  # Prompt user for github handle
+  echo "What is your GitHub username?"
+  read USER
+
+  # Prompt user for Cohort id
+  echo "What is your COHORT ID? (i.e hrr47)"
+  read COHORT
+
+  # Prompt user on whether they have started/completed FEC
+  echo "Have you started or completed FEC? (y[es] / n[o])"
+  # Tells user to respond with y/n if invalid input
+  select yn in "Yes" "No"
+  case $yn in
+    # If yes, run promptTeam helper
+    Yes ) promptTeam;;
+    # If no, set FEC to false
+    No ) FEC=false;;
+  esac
+}
+
+# If the three required options aren't included in prompt, run promptUser
+if [ $# != 3 ]; then
+  promptUser
+fi
+
+# Clone helper function
+clone () {
+  git clone "https://github.com/$USER/$1"
+}
+
+# Shortcut for mkdir then cd
 mkcd() {
   mkdir $1
   cd $1
@@ -30,84 +62,71 @@ cd ..
 
 # Pull Week 1 Items
 mkcd Week-1
-clone $cohort-recursion-review
-clone $cohort-underbar-review
+clone $COHORT-recursion-review
+clone $COHORT-underbar-review
 cd ..
 
 # Pull Week 2 Items
 mkcd Week-2
-clone $cohort-data-structures
-clone $cohort-subclass-dance-party
-clone $cohort-beesbeesbees
-clone $cohort-6ees6ees6ees
-clone $cohort-n-queens
+clone $COHORT-data-structures
+clone $COHORT-subclass-dance-party
+clone $COHORT-beesbeesbees
+clone $COHORT-6ees6ees6ees
+clone $COHORT-n-queens
 cd ..
 
 # Pull Week 3 Items
 mkcd Week-3
-clone $cohort-chatterbox-client
-clone $cohort-recast.ly
-clone $cohort-react-components
-clone $cohort-a-synchronous-swim
+clone $COHORT-chatterbox-client
+clone $COHORT-recast.ly
+clone $COHORT-react-components
+clone $COHORT-a-synchronous-swim
 cd ..
 
 # Pull Week 4 Elements
 mkcd Week-4
-clone $cohort-sqool
-clone $cohort-promises
-clone $cohort-databases
-clone $cohort-cruddy-todo
-clone $cohort-shortly-express
+clone $COHORT-sqool
+clone $COHORT-promises
+clone $COHORT-databases
+clone $COHORT-cruddy-todo
+clone $COHORT-shortly-express
 cd ..
 
 # Pull Week 5 Items
 mkcd Week-5
-clone $cohort-fullstack-review
-clone $cohort-cowlist
-clone $cohort-mini-apps-1
+clone $COHORT-fullstack-review
+clone $COHORT-cowlist
+clone $COHORT-mini-apps-1
 cd ..
 
 # Week 6 Begins Front End Capstone
 
+# Function for cloning FEC repo using GitHub API for organzations
+mkFEC () {
+  mkcd front-end-capstone
+  curl "https://api.github.com/orgs/$TEAM/repos?per_page=1000" | grep -o 'git@[^"]*' | xargs -L1 git clone
+  cd ..
+}
 
-mkcd front-end-capstone
+# If FEC is true or TEAM is not false then run mkFEC to clone org repos
+if [[ FEC == true || TEAM != false ]]; then
+  mkFEC
+fi
 
-#  Add your project's repos here
-#  git clone https://github.com/your-org/your-repo
-
-# This creates as sh script that will iterate through all repos in
-#    your FEC folder, pulls the master and installs modules
-echo "
-  for Dir in *; do
-    if [ -d \"\$Dir\" ]; then
-      cd \"\$Dir\"
-      git checkout master
-      git pull origin master
-      npm install
-      cd ..
-    fi
-  done
-
-  echo \"\"
-  echo \"========================\"
-  echo \"All Repos Up to Date\"
-  echo \"\"
-" > pullall.sh
-cd ..
 
 # Pull Self-Assessments
-# Self Asssessments may need versioning for further cohorts
+# Self Asssessments may need versioning for further COHORTs
 
 mkcd Self-Assessments
-clone $cohort-self-assessment-week-00-v4r
-clone $cohort-self-assessment-week-01-v3r
-clone $cohort-self-assessment-week-02-v5r
-clone $cohort-self-assessment-week-03-v7r
-clone $cohort-self-assessment-week-04-v5r
+clone $COHORT-self-assessment-week-00-v4r
+clone $COHORT-self-assessment-week-01-v3r
+clone $COHORT-self-assessment-week-02-v5r
+clone $COHORT-self-assessment-week-03-v7r
+clone $COHORT-self-assessment-week-04-v5r
 cd ..
 
 # Pull Other Projects
-clone $cohort-toy-problems
-clone $cohort-d3
+clone $COHORT-toy-problems
+clone $COHORT-d3
 
 

--- a/readme.md
+++ b/readme.md
@@ -1,0 +1,39 @@
+# Instructions
+---
+1. Clone repo
+1. Open terminal window in cloned folder
+1. run `chmod +x clone-hr.sh`
+1. Run in either no-prompt mode or prompt mode (see below for details).
+
+## Run Modes
+---
+### No prompt mode:
+
+If you want the script to run without interupts or asking you any questions, run the following command **with all 3 options (with no brackets around the options)**:
+
+`./clone-hr.sh [USERNAME] [COHORT] [FEC]`
+
+#### [USERNAME]
+Your GitHub username. i.e. `github.com/superNeatUsername/` then you'd replace [USERNAME] with `superNeatUsername`
+
+#### [COHORT]
+Your Cohort ID as it appears in your GitHub repos. i.e. if your Toy Problems repo is `github.com/superNeatUsername/hrr47-toy-problems`, then you'd replace [COHORT] with `hrr47`
+
+#### [FEC]
+Has multiple options/variables.
+
+If you have not started/completed FEC or you **do not* want to clone your FEC organziational repos, then replace [FEC] with `false`
+
+If you have started/completed FEC and you **do** want to clone your all your FEC organization's repos, you need to enter in your FEC organization name **as it was created on GitHub**.
+
+* **Example**: If your FEC organization's repo on GitHub is `github.com/wackyTeamName` then replace [FEC] with `wackyTeamName`
+* **Example**: If your FEC component's repo on GitHub is `github.com/wackyTeamName/ofCourseYouPickAnImageCarousel` then replace [FEC] with `wackyTeamName`
+
+#### Full run command example
+
+`./clone-hr.sh superNeatUsername hrr47 wackyTeamName`
+
+
+### Prompt Mode:
+
+If you don't enter any options or you fail to provide all options at run, the script will prompt you at each step to input the required information. If you answer "no" to the FEC question, you will not be prompted to provide an FEC organaztion name.


### PR DESCRIPTION
@lennee Awesome idea! I made a few changes to the script based on my usage. I started out adding to it because the FEC component cloning did not work when I attempted to run it. So initially I was just going to fix that and then have the script run `chmod +x` then run the config-fec.sh after it's creatation but it kind of branched off from there into something a little different.

My PR maintains most of your original functionality, the biggest difference however is it doesn't run the npm commands after cloning the FEC components because I used a curl command on the GitHub API for cloning all repos in an organization. In fact, if you really wanted to, you could use a similar curl command to clone all of a individual user's repos, but there are two problems with that:

1. It would clone all that user's repos, not just HR repos
1. In order to clone the HR private repos, it would require the user generate an access token to be inserted into the curl command.

If you don't want to merge my PR, no biggie, but I just thought since I had made some changes and pushed it to GitHub, I would see if you thought any of the changes and/or ideas would be helpful for your usage at all.

- Added bash prompts instead of error message if script is run without options
- Changed FEC clone to a curl command using the GitHub API for cloning complete organizations
- Added instructions in Readme